### PR TITLE
making selectors have a single type

### DIFF
--- a/src/main/java/org/contractlib/ast/Abstraction.java
+++ b/src/main/java/org/contractlib/ast/Abstraction.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public record Abstraction(
     List<String> params,
-    List<Pair<String, List<Pair<String, List<Type>>>>> constrs
+    List<Pair<String, List<Pair<String, Type>>>> constrs
 ) {
 }

--- a/src/main/java/org/contractlib/ast/Datatype.java
+++ b/src/main/java/org/contractlib/ast/Datatype.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public record Datatype(
     List<String> params,
-    List<Pair<String, List<Pair<String, List<Type>>>>> constrs
+    List<Pair<String, List<Pair<String, Type>>>> constrs
 ) {
 }

--- a/src/main/java/org/contractlib/ast/Factory.java
+++ b/src/main/java/org/contractlib/ast/Factory.java
@@ -99,7 +99,7 @@ public class Factory implements org.contractlib.factory.Commands<Term, Type, Abs
             return empty.extend(params);
         }
 
-        public Datatype datatype(List<String> params, List<Pair<String, List<Pair<String, List<Type>>>>> constrs) {
+        public Datatype datatype(List<String> params, List<Pair<String, List<Pair<String, Type>>>> constrs) {
             return new Datatype(params, constrs);
         }
     }
@@ -112,7 +112,7 @@ public class Factory implements org.contractlib.factory.Commands<Term, Type, Abs
 
         @Override
         public Abstraction abstraction(List<String> params,
-                                       List<Pair<String, List<Pair<String, List<Type>>>>> constructors) {
+                                       List<Pair<String, List<Pair<String, Type>>>> constructors) {
             return new Abstraction(params, constructors);
         }
     }

--- a/src/main/java/org/contractlib/factory/Abstractions.java
+++ b/src/main/java/org/contractlib/factory/Abstractions.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface Abstractions<TYPE, ABSTRACTION> {
     Types<TYPE> types(List<String> params);
 
-    ABSTRACTION abstraction(List<String> params, List<Pair<String, List<Pair<String, List<TYPE>>>>> constructors);
+    ABSTRACTION abstraction(List<String> params, List<Pair<String, List<Pair<String, TYPE>>>> constructors);
 }

--- a/src/main/java/org/contractlib/factory/Datatypes.java
+++ b/src/main/java/org/contractlib/factory/Datatypes.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface Datatypes<TYPE, DATATYPE> {
     Types<TYPE> types(List<String> params);
 
-    DATATYPE datatype(List<String> params, List<Pair<String, List<Pair<String, List<TYPE>>>>> constructors);
+    DATATYPE datatype(List<String> params, List<Pair<String, List<Pair<String, TYPE>>>> constructors);
 }

--- a/src/main/java/org/contractlib/parser/ContractLibANTLRParser.java
+++ b/src/main/java/org/contractlib/parser/ContractLibANTLRParser.java
@@ -85,7 +85,7 @@ public class ContractLibANTLRParser<TERM, TYPE, ABS, DT, FUNDECL, COMMAND> exten
                                             List<String> params,
                                             Types<TYPE> context,
                                             List<Pair<String, Integer>> arities) {
-        List<Pair<String, List<Pair<String, List<TYPE>>>>> constrs = new ArrayList<>();
+        List<Pair<String, List<Pair<String, TYPE>>>> constrs = new ArrayList<>();
         for (var ctr : ctx.constructor_dec()) {
             constrs.add(convertConstructor(ctr, context));
         }
@@ -93,15 +93,15 @@ public class ContractLibANTLRParser<TERM, TYPE, ABS, DT, FUNDECL, COMMAND> exten
         return abs.abstraction(params, constrs);
     }
 
-    private Pair<String, List<Pair<String, List<TYPE>>>> convertConstructor(ContractLIBParser.Constructor_decContext constr,
+    private Pair<String, List<Pair<String, TYPE>>> convertConstructor(ContractLIBParser.Constructor_decContext constr,
                                                                             Types<TYPE> params) {
         String ctrName = convertSymbol(constr.symbol());
-        List<Pair<String, List<TYPE>>> selectors = new ArrayList<>();
+        List<Pair<String, TYPE>> selectors = new ArrayList<>();
         for (var selector : constr.selector_dec()) {
             String name = convertSymbol(selector.symbol());
             TYPE t = convertSort(selector.sort(), params);
 
-            Pair<String, List<TYPE>> sel = new Pair<>(name, List.of(t));
+            Pair<String, TYPE> sel = new Pair<>(name, t);
             selectors.add(sel);
         }
         return new Pair<>(ctrName, selectors);
@@ -306,7 +306,7 @@ public class ContractLibANTLRParser<TERM, TYPE, ABS, DT, FUNDECL, COMMAND> exten
                                         List<String> params,
                                         Types<TYPE> context,
                                         List<Pair<String, Integer>> arities) {
-        List<Pair<String, List<Pair<String, List<TYPE>>>>> constrs = new ArrayList<>();
+        List<Pair<String, List<Pair<String, TYPE>>>> constrs = new ArrayList<>();
         for (var ctr : ctx.constructor_dec()) {
             constrs.add(convertConstructor(ctr, context));
         }

--- a/src/main/java/org/contractlib/parser/HandwrittenParser.java
+++ b/src/main/java/org/contractlib/parser/HandwrittenParser.java
@@ -126,12 +126,12 @@ public class HandwrittenParser extends Scanner {
         return repeat(() -> type(context));
     }
 
-    public <Type> List<Pair<String, List<Pair<String, List<Type>>>>> constructors(Types<Type> context)
+    public <Type> List<Pair<String, List<Pair<String, Type>>>> constructors(Types<Type> context)
             throws IOException {
         return repeat(() -> constructor(context));
     }
 
-    public <Type> List<Pair<String, List<Type>>> selectors(Types<Type> context) throws IOException {
+    public <Type> List<Pair<String, Type>> selectors(Types<Type> context) throws IOException {
         return repeat(() -> selector(context));
     }
 
@@ -184,25 +184,25 @@ public class HandwrittenParser extends Scanner {
         }
     }
 
-    public <Type> Pair<String, List<Type>> selector(Types<Type> context) throws IOException {
+    public <Type> Pair<String, Type> selector(Types<Type> context) throws IOException {
         if (check(LPAREN)) {
             String name = identifier();
-            List<Type> types = types(context);
+            Type types = type(context);
             expect(RPAREN);
 
-            return new Pair(name, types);
+            return new Pair<>(name, types);
         } else {
             return null;
         }
     }
 
-    public <Type> Pair<String, List<Pair<String, List<Type>>>> constructor(Types<Type> context) throws IOException {
+    public <Type> Pair<String, List<Pair<String, Type>>> constructor(Types<Type> context) throws IOException {
         if (check(LPAREN)) {
             String name = identifier();
-            List<Pair<String, List<Type>>> selectors = selectors(context);
+            List<Pair<String, Type>> selectors = selectors(context);
             expect(RPAREN);
 
-            return new Pair(name, selectors);
+            return new Pair<>(name, selectors);
         } else {
             return null;
         }
@@ -214,7 +214,7 @@ public class HandwrittenParser extends Scanner {
             Term postcondition = term(context, scope);
             expect(RPAREN);
 
-            return new Pair(precondition, postcondition);
+            return new Pair<>(precondition, postcondition);
 
         } else {
             return null;
@@ -265,7 +265,7 @@ public class HandwrittenParser extends Scanner {
         if (peek(LPAREN)) {
             return maybeParametricWithImplicitLParen((params) -> {
                 Types<Type> context = data.types(params);
-                List<Pair<String, List<Pair<String, List<Type>>>>> constructors = constructors(context);
+                List<Pair<String, List<Pair<String, Type>>>> constructors = constructors(context);
                 expect(RPAREN);
 
                 return data.datatype(params, constructors);
@@ -279,7 +279,7 @@ public class HandwrittenParser extends Scanner {
         if (peek(LPAREN)) {
             return maybeParametricWithImplicitLParen((params) -> {
                 Types<Type> context = data.types(params);
-                List<Pair<String, List<Pair<String, List<Type>>>>> constructors = constructors(context);
+                List<Pair<String, List<Pair<String, Type>>>> constructors = constructors(context);
                 expect(RPAREN);
 
                 return data.abstraction(params, constructors);

--- a/src/test/java/org/contractlib/AntlrParserTests.java
+++ b/src/test/java/org/contractlib/AntlrParserTests.java
@@ -34,7 +34,7 @@ class AntlrParserTests {
 
         ContractLIBParser.ScriptContext ctx = parser.script();
         Factory factory = new Factory();
-        ContractLibANTLRParser<Term, Type, Abstraction, Datatype, FunDec, Command> converter = new ContractLibANTLRParser<>(factory);
+        ContractLibANTLRParser<Term, Type, Abstraction, Datatype, FunDecl, Command> converter = new ContractLibANTLRParser<>(factory);
         converter.visit(ctx);
 
         StringBuilder sb = new StringBuilder();
@@ -62,7 +62,7 @@ class AntlrParserTests {
 
         ContractLIBParser.ScriptContext ctx = parser.script();
         Factory factory = new Factory();
-        ContractLibANTLRParser<Term, Type, Abstraction, Datatype, FunDec, Command> converter = new ContractLibANTLRParser<>(factory);
+        ContractLibANTLRParser<Term, Type, Abstraction, Datatype, FunDecl, Command> converter = new ContractLibANTLRParser<>(factory);
         converter.visit(ctx);
 
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
From `List<Pair<String, List<Pair<String, List<TYPE>>>>> constructors` to `List<Pair<String, List<Pair<String, TYPE>>>>` constructors